### PR TITLE
Replace 'mTabContainer' with 'tabContainer'

### DIFF
--- a/components/Main.js
+++ b/components/Main.js
@@ -1583,7 +1583,7 @@ Main.prototype.getTabFromWin=function(domWin){
       var tabbrowser=win.getBrowser();
       var ind=tabbrowser.getBrowserIndexForDocument(domWin.top.document);
       if(ind<0)continue;
-      var tab = tabbrowser.mTabContainer.childNodes[ind];
+      var tab = tabbrowser.tabContainer.childNodes[ind];
       if(tab)return tab;
     }
   }catch (e){


### PR DESCRIPTION
`mTabContainer` was deprecated and has been removed in [bug 1387009](https://bugzilla.mozilla.org/show_bug.cgi?id=1387009).