### PR TITLE
Use nsIFilePicker.open instead of nsIFilePicker.show

### DIFF
--- a/chrome/content/pref-script.js
+++ b/chrome/content/pref-script.js
@@ -53,26 +53,27 @@ var script={
     fp.appendFilter ("Javascript","*.js");
     fp.appendFilters(Ci.nsIFilePicker.filterAll);
 
-    var rv = fp.show();
-    if (rv == Ci.nsIFilePicker.returnOK)
-    {
-      var file=fp.file;
-      var fname = file.leafName;
-      var fnd=fname.match(/(.+)(\.\S+?)$/);
-      if(fnd)fname=fnd[1];
-      var str=this.appMain.loadFile0(file);
-      Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService)
-        .notifyObservers(null, "startupcache-invalidate", null);
-      var inList=this.main.addScript(fname,str);
-      var ver=this.appMain.getScriptVal(fname,"ver");
-      if(!inList){
-        this.list.push(fname);
-        this.addItem(fname,ver);
-      }else{
-        var em=document.getElementById("id"+fname);
-        em.setAttribute("label",fname+(ver?"("+ver+")":""));
+    fp.open((rv) => {
+      if (rv == Ci.nsIFilePicker.returnOK)
+      {
+        var file=fp.file;
+        var fname = file.leafName;
+        var fnd=fname.match(/(.+)(\.\S+?)$/);
+        if(fnd)fname=fnd[1];
+        var str=this.appMain.loadFile0(file);
+        Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService)
+          .notifyObservers(null, "startupcache-invalidate", null);
+        var inList=this.main.addScript(fname,str);
+        var ver=this.appMain.getScriptVal(fname,"ver");
+        if(!inList){
+          this.list.push(fname);
+          this.addItem(fname,ver);
+        }else{
+          var em=document.getElementById("id"+fname);
+          em.setAttribute("label",fname+(ver?"("+ver+")":""));
+        }
       }
-    }
+    });
   },
   onDelete:function(){
     var obj=document.getElementById("xnotifier-scripts");


### PR DESCRIPTION
[Bug 1387800](https://bugzilla.mozilla.org/show_bug.cgi?id=1387800) removed the deprecated [`nsIFilePicker.show`](https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIFilePicker#show). The asynchronous [`nsIFilePicker.open`](https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIFilePicker#open) can be used instead. This change is necessary for adding custom X-Notifier scripts on Firefox 57.