### PR TITLE
Prefer nsPrefBranch::{get,set}StringPref() over nsPrefBranch::{get,set}ComplexValue

### DIFF
--- a/chrome/content/options.js
+++ b/chrome/content/options.js
@@ -207,18 +207,30 @@ function _setInt(host,user,name,val,defVal){
     }
   }
 }
+function getStringPref(prefStr) {
+  if (prefBranch.getStringPref) {
+    return prefBranch.getStringPref(prefStr);
+  }
+  return prefBranch.getComplexValue(prefStr, Components.interfaces.nsISupportsString).data;
+}
+function setStringPref(prefStr, str) {
+  if (prefBranch.setStringPref) {
+    return prefBranch.setStringPref(prefStr, str);
+  }
+  return prefBranch.setComplexValue(prefStr,Components.interfaces.nsISupportsString, str);
+}
 function _setUniChar(host,user,name,val){
   var prefStr=PREF_BRANCH+"["+host+"#"+user+"]."+name;
   var t=null;
   try{
-    t=prefBranch.getComplexValue(prefStr,Components.interfaces.nsISupportsString).data;
+    t = getStringPref(prefStr);
   }catch(e){}
   if(t!=val){
     if(val){
       var str = Components.classes["@mozilla.org/supports-string;1"]
             .createInstance(Components.interfaces.nsISupportsString);
       str.data = val;
-      prefBranch.setComplexValue(prefStr,Components.interfaces.nsISupportsString, str);
+      setStringPref(prefStr, str);
     }else{
       try{prefBranch.clearUserPref(prefStr);}catch(e){}
     }
@@ -415,10 +427,10 @@ function _getValues(o,isNew,byUser){
       o.autoOpen=prefBranch.getBoolPref(prefStr+"autoOpen");
     }catch(e){}
     try{
-      o.alias=prefBranch.getComplexValue(prefStr+"alias",Components.interfaces.nsISupportsString).data;
+      o.alias = getStringPref(prefStr + "alias");
     }catch(e){}
     try{
-      o.link=prefBranch.getComplexValue(prefStr+"link",Components.interfaces.nsISupportsString).data;
+      o.link = getStringPref(prefStr + "link");
     }catch(e){}
     try{
       o.interval=prefBranch.getIntPref(prefStr+"interval");
@@ -595,7 +607,7 @@ function onImport(){
             var s = Components.classes["@mozilla.org/supports-string;1"]
                     .createInstance(Components.interfaces.nsISupportsString);
             s.data = val[2];
-            prefBranch.setComplexValue(nm,Components.interfaces.nsISupportsString, s);
+            setStringPref(nm, s);
             break;
           case 1:
             prefBranch.setIntPref(nm,val[2]);
@@ -652,7 +664,7 @@ function onExport(){
       }
       switch(type){
       case Ci.nsIPrefBranch.PREF_STRING:
-        str+=nm+"\t0\t"+prefBranch.getComplexValue(o,Components.interfaces.nsISupportsString).data+"\r\n";
+        str += nm + "\t0\t" + getStringPref(o) + "\r\n";
         break;
       case Ci.nsIPrefBranch.PREF_INT:
         str+=nm+"\t1\t"+prefBranch.getIntPref(o)+"\r\n";

--- a/components/Main.js
+++ b/components/Main.js
@@ -110,7 +110,7 @@ function Main() {
       if(o=="mailSound")o2="alertSound";
       switch(type){
       case Ci.nsIPrefBranch.PREF_STRING:
-        this.prefBranch.setComplexValue(o2,Ci.nsISupportsString,pb.getComplexValue(o,Ci.nsISupportsString));
+        setStringPref(this.prefBranch, o2, getStringPref(pb, o));
         break;
       case Ci.nsIPrefBranch.PREF_INT:
         this.prefBranch.setIntPref(o2,pb.getIntPref(o));
@@ -536,7 +536,7 @@ Main.prototype.buildTable = function(onInit) {
         var o2=o;
         switch(type){
         case Ci.nsIPrefBranch.PREF_STRING:
-          pb2.setComplexValue(o2,Ci.nsISupportsString,pb.getComplexValue(o,Ci.nsISupportsString));
+          setStringPref(pb2, o2, getStringPref(pb, o));
           break;
         case Ci.nsIPrefBranch.PREF_INT:
           pb2.setIntPref(o2,pb.getIntPref(o));
@@ -610,7 +610,7 @@ Main.prototype.buildTable = function(onInit) {
       if(obj.needLocale)obj.needServer=true;
       if(obj.needServer)obj.server=obj.user.split("|")[1];
       try{
-        obj.link=pb.getComplexValue("link",Ci.nsISupportsString).data;
+        obj.link = getStringPref(pb, "link");
       }catch(e){}
       if(obj.init)obj.init();
       obj.setLoginData();
@@ -619,19 +619,19 @@ Main.prototype.buildTable = function(onInit) {
         obj.interval=pb.getIntPref("interval");
       }catch(e){}
       try{
-        obj.alias=pb.getComplexValue("alias",Ci.nsISupportsString).data;
+        obj.alias = getStringPref(pb, "alias");
       }catch(e){}
       try{
         obj.autoOpen=pb.getBoolPref("autoOpen");
       }catch(e){}
       try{
-        obj.icon=pb.getComplexValue("icon",Ci.nsISupportsString).data;
+        obj.icon = getStringPref(pb, "icon");
       }catch(e){}
       try{
-        obj.sound=pb.getComplexValue("sound",Ci.nsISupportsString).data;
+        obj.sound = getStringPref(pb, "sound");
       }catch(e){}
       try{
-        obj.keyword=pb.getComplexValue("keyword",Ci.nsISupportsString).data;
+        obj.keyword = getStringPref(pb, "keyword");
       }catch(e){}
       if(!this.prefBranch.getBoolPref("saveCookies"))delete obj.checkLogin;
       obj.inited=true;
@@ -1924,4 +1924,17 @@ Main.prototype.toggleDebug=function(){
   for(i=0;i<this.handlers.length;++i){
     this.handlers[i].debug=this.debug;
   }
+}
+
+function getStringPref(prefBranch, prefStr) {
+  if (prefBranch.getStringPref) {
+    return prefBranch.getStringPref(prefStr);
+  }
+  return prefBranch.getComplexValue(prefStr, Components.interfaces.nsISupportsString).data;
+}
+function setStringPref(prefBranch, prefStr, str) {
+  if (prefBranch.setStringPref) {
+    return prefBranch.setStringPref(prefStr, str);
+  }
+  return prefBranch.setComplexValue(prefStr, Components.interfaces.nsISupportsString, str);
 }


### PR DESCRIPTION
[Bug 1414096](https://bugzilla.mozilla.org/show_bug.cgi?id=1414096) removed support for `nsISupportsString` values in `nsPrefBranch::{get,set}ComplexValue()` in favor of `nsPrefBranch::{get,set}StringPref()`, added in [bug 1345294](https://bugzilla.mozilla.org/show_bug.cgi?id=1345294).